### PR TITLE
Don't sort by sentiment in sentiment_by

### DIFF
--- a/R/sentiment_by.R
+++ b/R/sentiment_by.R
@@ -83,10 +83,11 @@ sentiment_by <- function(text.var, by = NULL, group.names, ...){
 
         uncombined <- out2 <- cbind(group_dat, out)
 
-        out2 <- out2[, list('word_count' = sum(word_count, na.rm = TRUE),
-            'sd' = stats::sd(sentiment, na.rm = TRUE),
-            'ave_sentiment' = mean(sentiment, na.rm = TRUE)), keyby = G][order(-ave_sentiment)]
-
+        out2 <-
+            out2[, list(word_count = sum(word_count, na.rm = TRUE),
+                        sd = stats::sd(sentiment, na.rm = TRUE),
+                        ave_sentiment = mean(sentiment, na.rm = TRUE)),
+                 keyby = G]
     }
 
     class(out2) <- unique(c("sentiment_by", class(out)))


### PR DESCRIPTION
Usually grouping operators preserve the order of the groups. In this sense the behavior of sentiment_by is non-intuitive. Especially with data.table  `by` would better have the same semantics as in data.table. 

While sorting by sentiment is potentially useful in some contexts, there is virtually no advantage for it with current plotting functionality. Plotting by grouping values is probably more meaningful in majority of the cases. 

If they so desire, users can always sort by sentiment with a simple `setkey`. Sorting by keys is more verbose and results in unnecessary groups names replication.

For these reasons I would propose to remove this "feature".
